### PR TITLE
Use relative URLs for logos

### DIFF
--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -37,9 +37,8 @@ heading: U.S. Department of Justice
 # Configuration for agency logo(s) (shown side by side).
 # If the logo is external add external: true
 logos:
-  - src: https://raw.githubusercontent.com/18F/ada-sandbox/main/assets/img/doj.png
+  - src: assets/img/doj.png
     alt: U.S. Department of Justice Seal
-    external: true
 
 # Configuration for footer contact links
 contact:

--- a/_data/header.yml
+++ b/_data/header.yml
@@ -21,9 +21,8 @@ type: extended
 # Configuration for site header logo
 # If the logo is external add external: true
 logo:
-  src: https://raw.githubusercontent.com/18F/ada-sandbox/main/assets/img/ada-logo.svg
+  src: assets/img/ada-logo.svg
   alt: ADA
-  external: true
 
 # this is a key into _data/navigation.yml
 primary:


### PR DESCRIPTION
@brentryanjohnson I was able to get logos to load using a relative URL if I removed the `external: true` flag from the config. I *think* this achieves what you were looking for. Check out the preview URL and let me know if I missed anything.